### PR TITLE
follow curr_path through build symlink

### DIFF
--- a/spot_tools_ros/setup.py
+++ b/spot_tools_ros/setup.py
@@ -14,6 +14,7 @@ materials = output_path.rglob("spot.mtl")
 for material in materials:
     shutil.copytree(template_path, material.parent, dirs_exist_ok=True)
 
+
 def get_share_info(top_level, pattern, dest=None):
     dest = pathlib.Path("share") / package_name if dest is None else pathlib.Path(dest)
     files = [x.relative_to(curr_path) for x in (curr_path / top_level).rglob(pattern)]
@@ -67,5 +68,3 @@ setup(
         ],
     },
 )
-
-

--- a/spot_tools_ros/setup.py
+++ b/spot_tools_ros/setup.py
@@ -4,8 +4,8 @@ import shutil
 from setuptools import find_packages, setup
 
 package_name = "spot_tools_ros"
-curr_path = pathlib.Path(__file__).absolute().parent
-
+# resolve is required for symlink installs
+curr_path = pathlib.Path(__file__).resolve().parent
 
 # copies all base meshes to directories containing unique colors
 template_path = curr_path / "meshes" / "templates"
@@ -13,7 +13,6 @@ output_path = curr_path / "meshes" / "visual"
 materials = output_path.rglob("spot.mtl")
 for material in materials:
     shutil.copytree(template_path, material.parent, dirs_exist_ok=True)
-
 
 def get_share_info(top_level, pattern, dest=None):
     dest = pathlib.Path("share") / package_name if dest is None else pathlib.Path(dest)
@@ -48,7 +47,6 @@ data_files = (
     + mesh_files
 )
 
-
 setup(
     name=package_name,
     version="0.0.0",
@@ -69,3 +67,5 @@ setup(
         ],
     },
 )
+
+


### PR DESCRIPTION
Turns out colcon/ament symlinks `setup.py` into `build` when doing a symlink install, which breaks my script to generate the templates (and maybe any other `get_share_info` implementations). This fixes that