### PR TITLE
allow extending with macro

### DIFF
--- a/spot_tools_ros/urdf/empty.urdf
+++ b/spot_tools_ros/urdf/empty.urdf
@@ -1,6 +1,0 @@
-<robot>
-  <!-- This file is a placeholder which is included by default from
-       spot.urdf.xacro. If a robot is being customized and requires
-       additional URDF, set the SPOT_URDF_EXTRAS environment variable
-       to the full path of the file you would like included. -->
-</robot>

--- a/spot_tools_ros/urdf/empty.urdf.xacro
+++ b/spot_tools_ros/urdf/empty.urdf.xacro
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="load_extras" params="tf_prefix"/>
+</robot>

--- a/spot_tools_ros/urdf/spot.urdf.xacro
+++ b/spot_tools_ros/urdf/spot.urdf.xacro
@@ -14,10 +14,10 @@
   <xacro:arg name="gripperless" default="false" />
 
   <!-- Set to true to enable joints -->
-  <xacro:arg name="include_transmissions" default="true" />^M
+  <xacro:arg name="include_transmissions" default="true"/>
 
   <!-- Set to the accent color you want for spot -->
-  <xacro:arg name="spot_color" default="yellow" />
+  <xacro:arg name="spot_color" default="yellow"/>
 
   <!-- Load Spot -->
   <xacro:load_spot
@@ -25,6 +25,11 @@
     tf_prefix="$(arg tf_prefix)"
     spot_color="$(arg spot_color)"
     gripperless="$(arg gripperless)"
-    include_transmissions="$(arg include_transmissions)" />
+    include_transmissions="$(arg include_transmissions)"/>
+
+  <!-- Optional custom includes. -->
+  <xacro:arg name="extras_urdf" default="$(find spot_tools_ros)/urdf/empty.urdf.xacro"/>
+  <xacro:include filename="$(arg extras_urdf)"/>
+  <xacro:load_extras tf_prefix="$(arg tf_prefix)"/>
 
 </robot>

--- a/spot_tools_ros/urdf/spot_macro.xacro
+++ b/spot_tools_ros/urdf/spot_macro.xacro
@@ -552,10 +552,6 @@
                     </transmission>
         </xacro:if>
 
-        <!-- Optional custom includes. -->
-        <xacro:property name="default_empty_urdf" value="$(find spot_tools_ros)/urdf/empty.urdf" />
-        <xacro:include filename="$(optenv SPOT_URDF_EXTRAS ${default_empty_urdf})" />
-
         <!-- Include Arm if necessary-->
         <xacro:if value="${arm}">
             <xacro:include filename="$(find spot_tools_ros)/urdf/spot_arm_macro.urdf" />


### PR DESCRIPTION
Updates the extension mechanism for the spot urdf to allow for using the tf prefix (used downstream in adt4 to add the zed link to the main urdf). Need to actually test that the robot model still works though