### PR TITLE
Feature/graceful lease handoff

### DIFF
--- a/spot_tools/src/spot_executor/spot.py
+++ b/spot_tools/src/spot_executor/spot.py
@@ -64,6 +64,7 @@ class Spot:
             logging.warning("Spot does not have an arm, manipulation disabled!")
             self.manipulation_api_client = None
 
+        self.power_client = self.robot.ensure_client("power")
         self.estop_client = self.robot.ensure_client("estop")
         self.estop_keep_alive = None
         self.lease_client = self.robot.ensure_client("lease")

--- a/spot_tools/src/spot_executor/spot_executor.py
+++ b/spot_tools/src/spot_executor/spot_executor.py
@@ -67,6 +67,11 @@ class LeaseManager:
                 # If nobody owns the lease, then the owner string is empty.
                 # We should try to take the lease back in that case.
                 if owner.client_name == "":
+                    # We should set the feedback's break_out_of_waiting_loop to True
+                    # so that the pick skill gets immediately cancelled if it is running.
+                    if self.feedback is not None:
+                        self.feedback.break_out_of_waiting_loop = True
+
                     self.taking_back_lease = True
                     if self.feedback is not None:
                         self.feedback.print(

--- a/spot_tools/src/spot_executor/spot_executor.py
+++ b/spot_tools/src/spot_executor/spot_executor.py
@@ -52,6 +52,10 @@ class SpotExecutor:
         self.keep_going = True
         self.processing_action_sequence = False
 
+        # For determining if we should continue a previously executed sequence
+        self.current_action_sequence = None
+        self.current_action_sequence_idx = None
+
     def terminate_sequence(self, feedback):
         # Tell the actions sequence to break
         self.keep_going = False

--- a/spot_tools/src/spot_skills/grasp_utils.py
+++ b/spot_tools/src/spot_skills/grasp_utils.py
@@ -38,7 +38,6 @@ from spot_skills.arm_utils import (
     stow_arm,
 )
 from spot_skills.detection_utils import Detector
-from spot_skills.primitives import execute_recovery_action
 
 g_image_click = None
 g_image_display = None
@@ -203,11 +202,17 @@ def object_grasp(
             print("Found object centroid:", xy)
 
     if xy is None:
-        execute_recovery_action(spot, recover_arm=True)
-        spot.sit()
-        raise Exception(
-            "Failed to find an object in any cameras after 2 attempts. Please check the detector or user input."
-        )
+        if feedback is not None:
+            feedback.print(
+                "INFO",
+                "Failed to find an object in any cameras after 2 attempts. Please check the detector or user input.",
+            )
+        return False
+        # execute_recovery_action(spot, recover_arm=True)
+        # spot.sit()
+        # raise Exception(
+        #     "Failed to find an object in any cameras after 2 attempts. Please check the detector or user input."
+        # )
 
     # If xy is not None, then display the annotated image
     else:
@@ -222,9 +227,8 @@ def object_grasp(
             )
 
             if response is not None and not response:
-                raise Exception(
-                    "The user determined that the detection was invalid. Aborting."
-                )
+                feedback.print("INFO", "User requested abort.")
+                return False
 
     pick_vec = geometry_pb2.Vec2(x=xy[0], y=xy[1])
     stow_arm(spot)

--- a/spot_tools_ros/examples/test_spot_executor_ros.py
+++ b/spot_tools_ros/examples/test_spot_executor_ros.py
@@ -8,8 +8,6 @@ from visualization_msgs.msg import MarkerArray
 from robot_executor_interface.action_descriptions import (
     ActionSequence,
     Follow,
-    Gaze,
-    Pick,
 )
 
 
@@ -31,26 +29,26 @@ class Tester(Node):
         path = np.array(
             [
                 [0.0, 0],
-                [1.0, 0],
-                [3.0, 5],
-                [5.0, 5],
+                [10.8, 0],
+                # [3.0, 5],
+                # [5.0, 5],
             ]
         )
 
         follow_cmd = Follow("hamilton/odom", path)
 
-        gaze_cmd = Gaze(
-            "hamilton/odom",
-            np.array([5.0, 5, 0]),
-            np.array([7.0, 7, 0]),
-            stow_after=True,
-        )
+        # gaze_cmd = Gaze(
+        #    "hamilton/odom",
+        #    np.array([5.0, 5, 0]),
+        #    np.array([7.0, 7, 0]),
+        #    stow_after=True,
+        # )
 
-        pick_cmd = Pick(
-            "hamilton/odom", "bag", np.array([5.0, 5, 0]), np.array([7.0, 7, 0])
-        )
+        # pick_cmd = Pick(
+        #    "hamilton/odom", "bag", np.array([5.0, 5, 0]), np.array([7.0, 7, 0])
+        # )
 
-        seq = ActionSequence("id0", "spot", [follow_cmd, gaze_cmd, pick_cmd])
+        seq = ActionSequence("id0", "spot", [follow_cmd])
 
         publisher.publish(to_msg(seq))
         viz_publisher.publish(to_viz_msg(seq, "planner_ns"))

--- a/spot_tools_ros/examples/test_spot_executor_ros.py
+++ b/spot_tools_ros/examples/test_spot_executor_ros.py
@@ -5,10 +5,7 @@ from robot_executor_interface_ros.action_descriptions_ros import to_msg, to_viz_
 from robot_executor_msgs.msg import ActionSequenceMsg
 from visualization_msgs.msg import MarkerArray
 
-from robot_executor_interface.action_descriptions import (
-    ActionSequence,
-    Follow,
-)
+from robot_executor_interface.action_descriptions import ActionSequence, Follow, Pick
 
 
 class Tester(Node):
@@ -29,7 +26,7 @@ class Tester(Node):
         path = np.array(
             [
                 [0.0, 0],
-                [10.8, 0],
+                [3.8, 0],
                 # [3.0, 5],
                 # [5.0, 5],
             ]
@@ -44,11 +41,11 @@ class Tester(Node):
         #    stow_after=True,
         # )
 
-        # pick_cmd = Pick(
-        #    "hamilton/odom", "bag", np.array([5.0, 5, 0]), np.array([7.0, 7, 0])
-        # )
+        pick_cmd = Pick(
+            "hamilton/odom", "bag", np.array([5.0, 5, 0]), np.array([7.0, 7, 0])
+        )
 
-        seq = ActionSequence("id0", "spot", [follow_cmd])
+        seq = ActionSequence("id0", "spot", [follow_cmd, pick_cmd])
 
         publisher.publish(to_msg(seq))
         viz_publisher.publish(to_viz_msg(seq, "planner_ns"))

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -1,6 +1,7 @@
 import threading
 import time
 
+import bosdyn
 import cv2
 import numpy as np
 import rclpy
@@ -408,9 +409,13 @@ class SpotExecutorRos(Node):
             self.status_str = "Processing action sequence"
             self.get_logger().info("Starting action sequence")
             sequence = from_msg(msg)
-            self.spot_executor.process_action_sequence(
-                sequence, self.feedback_collector
-            )
+            try:
+                self.spot_executor.process_action_sequence(
+                    sequence, self.feedback_collector
+                )
+            except bosdyn.client.exceptions.LeaseUseError as e:
+                self.get_logger().info(f"Lease Taken: {e.error_message}")
+
             self.get_logger().info("Finished execution action sequence.")
             self.status_str = "Idle"
 

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -380,8 +380,8 @@ class SpotExecutorRos(Node):
             tf_lookup_fn,
             follower_lookahead,
             goal_tolerance,
-            feedback=self.feedback_collector,
         )
+        self.spot_executor.initialize_lease_manager(self.feedback_collector)
 
         self.action_sequence_sub = self.create_subscription(
             ActionSequenceMsg,

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -9,7 +9,6 @@ import spot_executor as se
 import tf2_ros
 import tf_transformations
 import yaml
-from bosdyn.client.exceptions import LeaseUseError
 from cv_bridge import CvBridge
 from nav_msgs.msg import Path
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
@@ -410,12 +409,10 @@ class SpotExecutorRos(Node):
             self.status_str = "Processing action sequence"
             self.get_logger().info("Starting action sequence")
             sequence = from_msg(msg)
-            try:
-                self.spot_executor.process_action_sequence(
-                    sequence, self.feedback_collector
-                )
-            except LeaseUseError as e:
-                self.get_logger().info(f"Lease Taken: {e.error_message}")
+
+            self.spot_executor.process_action_sequence(
+                sequence, self.feedback_collector
+            )
 
             self.get_logger().info("Finished execution action sequence.")
             self.status_str = "Idle"

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -1,7 +1,6 @@
 import threading
 import time
 
-import bosdyn
 import cv2
 import numpy as np
 import rclpy
@@ -10,6 +9,7 @@ import spot_executor as se
 import tf2_ros
 import tf_transformations
 import yaml
+from bosdyn.client.exceptions import LeaseUseError
 from cv_bridge import CvBridge
 from nav_msgs.msg import Path
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
@@ -413,7 +413,7 @@ class SpotExecutorRos(Node):
                 self.spot_executor.process_action_sequence(
                     sequence, self.feedback_collector
                 )
-            except bosdyn.client.exceptions.LeaseUseError as e:
+            except LeaseUseError as e:
                 self.get_logger().info(f"Lease Taken: {e.error_message}")
 
             self.get_logger().info("Finished execution action sequence.")

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -266,6 +266,7 @@ class SpotExecutorRos(Node):
         self.declare_parameter("goal_tolerance", 0.0)
         goal_tolerance = self.get_parameter("goal_tolerance").value
         assert goal_tolerance > 0
+        self.get_logger().info(f"{goal_tolerance=}")
 
         # Pick/Inspect Skill
         self.declare_parameter("semantic_model_path", "")

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -380,6 +380,7 @@ class SpotExecutorRos(Node):
             tf_lookup_fn,
             follower_lookahead,
             goal_tolerance,
+            feedback=self.feedback_collector,
         )
 
         self.action_sequence_sub = self.create_subscription(


### PR DESCRIPTION
This nominally supports the graceful handoff between the spot executor and the tablet. It works well when the robot is following a continuous trajectory, but is a little less clean for the pick skill. 

**Pick Skill Comments** We want to exit out of the pick skill when we lose the lease, but this does not happen until we actually try to pick up the object. If the detector has detected an object and the lease is hijacked, the pick skill will continue waiting for the user to confirm the detection is valid. If the user confirms before the lease is returned, a LeaseUseError will be thrown when the robot actually tries to pick up the object. HOWEVER, if the lease is returned and THEN the user confirms the detection, the robot will try to pick up the object with potentially the wrong xy location (e.g., if the robot was moved by the user). Thus, we need to raise a LeaseUserError if we lose the lease when we are waiting for confirmation. 

**Potential Solutions** The RosFeedbackCollector does not have access to the spot_interface, so it cannot check if we have the lease. Currently, the LeaseManager does not have access to the RosFeedbackCollector instance (but could), where it would then set feedback.break_out_of_waiting_loop to True. @GoldenZephyr thoughts on passing feedback to monitor_lease? 