### PR TITLE
Feature/plan repair preemption

### DIFF
--- a/spot_tools/src/spot_executor/fake_spot.py
+++ b/spot_tools/src/spot_executor/fake_spot.py
@@ -150,12 +150,23 @@ class FakeCommandClient:
                 0
             ].pose.angle
 
-            z = self.fake_spot.get_pose()[2]
+            # Interpolate toward goal instead of teleporting
+            cur = self.fake_spot.get_pose()
+            z = cur[2]
+            dx = x - cur[0]
+            dy = y - cur[1]
+            dist = np.sqrt(dx**2 + dy**2)
+            max_step = self.fake_spot.fake_speed * 0.1  # speed * dt (10 Hz)
+            if dist > max_step:
+                ratio = max_step / dist
+                x = cur[0] + dx * ratio
+                y = cur[1] + dy * ratio
             self.fake_spot.set_pose((x, y, z, angle))
             self.fake_spot.moving = True
             self.fake_spot.last_move_command = time.time()
 
-        time.sleep(0.5)
+        # Short sleep so follow_trajectory_continuous can check cancel_cb frequently (~10 Hz)
+        time.sleep(0.1)
 
     def robot_command_feedback(self, cmd_id):
         print("Spot would return command feedback for cmd_id ", cmd_id)
@@ -230,6 +241,7 @@ class FakeSpot:
 
         self.moving = False
         self.last_move_command = time.time()
+        self.fake_speed = 4.0  # m/s for simulated movement (adjust to slow down)
 
         self.cmd_vel_linear = np.zeros(3)
         self.cmd_vel_angular = np.zeros(3)

--- a/spot_tools/src/spot_executor/spot_executor.py
+++ b/spot_tools/src/spot_executor/spot_executor.py
@@ -18,6 +18,7 @@ from scipy.spatial.transform import Rotation
 from spot_skills.arm_utils import gaze_at_vision_pose
 from spot_skills.grasp_utils import object_grasp, object_place, stow_arm
 from spot_skills.navigation_utils import (
+    command_zero_velocity,
     follow_trajectory_continuous,
     turn_to_point,
 )
@@ -168,8 +169,7 @@ class SpotExecutor:
                 "INFO", "Pausing current action sequence; commanding Spot to stop."
             )
             try:
-                if hasattr(self.spot_interface, "set_vel"):
-                    self.spot_interface.set_vel(np.zeros(3), np.zeros(3))
+                command_zero_velocity(self.spot_interface, feedback)
                 if hasattr(self.spot_interface, "stand"):
                     self.spot_interface.stand()
             except Exception as ex:
@@ -191,11 +191,11 @@ class SpotExecutor:
 
         # Try to bring the robot to an immediate, safe stop
         try:
-            # FakeSpot / sim: zero out velocity if supported
-            if hasattr(self.spot_interface, "set_vel"):
-                self.spot_interface.set_vel(np.zeros(3), np.zeros(3))
+            # Zero velocity through whichever interface this Spot exposes
+            # (set_vel on FakeSpot, set_twist on the real robot)
+            command_zero_velocity(self.spot_interface, feedback)
 
-            # Real Spot: command a stand to hold position and cancel walking if API is available
+            # Command a stand to hold position and cancel walking if API is available
             if hasattr(self.spot_interface, "stand"):
                 self.spot_interface.stand()
         except Exception as ex:

--- a/spot_tools/src/spot_executor/spot_executor.py
+++ b/spot_tools/src/spot_executor/spot_executor.py
@@ -160,6 +160,31 @@ class SpotExecutor:
     def initialize_lease_manager(self, feedback):
         self.lease_manager = LeaseManager(self.spot_interface, feedback)
 
+    def _reclaim_lease_for_stop(self, feedback):
+        """Take the body lease back so a stop command is actually accepted.
+
+        Another client -- the tablet, a teleop node, a previous run -- may hold
+        the lease, and Spot rejects our RobotCommand with LeaseUseError until we
+        own it, which means the stop silently does nothing and the robot keeps
+        walking. take() is the same forceful reclaim that
+        process_action_sequence and the lease manager thread already perform; on
+        the preemption path process_action_sequence takes the lease moments
+        later anyway, so this only moves the reclaim ahead of the stop that
+        depends on it.
+        """
+        if not hasattr(self.spot_interface, "take_lease"):
+            return
+
+        try:
+            self.spot_interface.take_lease()
+        except Exception as ex:
+            # Best-effort: if we can't reclaim, the caller's stop attempt will
+            # fail too, but it should still report that rather than abort here.
+            feedback.print(
+                "WARNING",
+                f"Could not take the lease back before stopping Spot: {ex}",
+            )
+
     def set_paused(self, value: bool, feedback):
         with self._pause_lock:
             self.paused = value
@@ -169,6 +194,7 @@ class SpotExecutor:
                 "INFO", "Pausing current action sequence; commanding Spot to stop."
             )
             try:
+                self._reclaim_lease_for_stop(feedback)
                 command_zero_velocity(self.spot_interface, feedback)
                 if hasattr(self.spot_interface, "stand"):
                     self.spot_interface.stand()
@@ -191,6 +217,10 @@ class SpotExecutor:
 
         # Try to bring the robot to an immediate, safe stop
         try:
+            # Reclaim authority first -- without the body lease the zero-velocity
+            # command below is rejected and Spot keeps executing the old plan.
+            self._reclaim_lease_for_stop(feedback)
+
             # Zero velocity through whichever interface this Spot exposes
             # (set_vel on FakeSpot, set_twist on the real robot)
             command_zero_velocity(self.spot_interface, feedback)

--- a/spot_tools/src/spot_executor/spot_executor.py
+++ b/spot_tools/src/spot_executor/spot_executor.py
@@ -116,7 +116,7 @@ class LeaseManager:
                         else:
                             if self.feedback is not None:
                                 self.feedback.print(
-                                    "WARN",
+                                    "WARNING",
                                     "LEASE MANAGER THREAD: Could not clear all behavior faults, cannot stand.",
                                 )
                     time.sleep(1)
@@ -174,7 +174,7 @@ class SpotExecutor:
                     self.spot_interface.stand()
             except Exception as ex:
                 feedback.print(
-                    "WARN",
+                    "WARNING",
                     f"Failed to stop/stand Spot on pause; robot may still be moving: {ex}",
                 )
         else:
@@ -202,7 +202,7 @@ class SpotExecutor:
             # Hard stop is best-effort; failures here shouldn't block termination,
             # but we must not swallow this silently -- the robot may still be moving.
             feedback.print(
-                "WARN",
+                "WARNING",
                 f"Failed to bring Spot to a hard stop during termination: {ex}",
             )
 

--- a/spot_tools/src/spot_executor/spot_executor.py
+++ b/spot_tools/src/spot_executor/spot_executor.py
@@ -148,22 +148,63 @@ class SpotExecutor:
         self.goal_tolerance = goal_tolerance
         self.detector = detector
         self.keep_going = True
+        self.paused = False
         self.processing_action_sequence = False
         self.mid_level_planner = planner
         self.use_fake_path_planner = use_fake_path_planner
+        self._pause_lock = threading.Lock()
 
         self.lease_manager = None
 
     def initialize_lease_manager(self, feedback):
         self.lease_manager = LeaseManager(self.spot_interface, feedback)
 
-    def terminate_sequence(self, feedback):
-        # Tell the actions sequence to break
-        self.keep_going = False
+    def set_paused(self, value: bool, feedback):
+        with self._pause_lock:
+            self.paused = value
 
-        # Blocking the thread so that it terminates cleanly by
-        # terminating the pick action and waiting for processing to end
+        if value:
+            feedback.print(
+                "INFO", "Pausing current action sequence; commanding Spot to stop."
+            )
+            try:
+                if hasattr(self.spot_interface, "set_vel"):
+                    self.spot_interface.set_vel(np.zeros(3), np.zeros(3))
+                if hasattr(self.spot_interface, "stand"):
+                    self.spot_interface.stand()
+            except Exception as ex:
+                feedback.print(
+                    "WARN",
+                    f"Failed to stop/stand Spot on pause; robot may still be moving: {ex}",
+                )
+        else:
+            feedback.print("INFO", "Resuming current action sequence.")
+
+    def terminate_sequence(self, feedback):
+        # Tell the action sequence loop to break
+        self.keep_going = False
+        with self._pause_lock:
+            self.paused = False
+
+        # Ask any blocking feedback waits to exit
         feedback.break_out_of_waiting_loop = True
+
+        # Try to bring the robot to an immediate, safe stop
+        try:
+            # FakeSpot / sim: zero out velocity if supported
+            if hasattr(self.spot_interface, "set_vel"):
+                self.spot_interface.set_vel(np.zeros(3), np.zeros(3))
+
+            # Real Spot: command a stand to hold position and cancel walking if API is available
+            if hasattr(self.spot_interface, "stand"):
+                self.spot_interface.stand()
+        except Exception as ex:
+            # Hard stop is best-effort; failures here shouldn't block termination,
+            # but we must not swallow this silently -- the robot may still be moving.
+            feedback.print(
+                "WARN",
+                f"Failed to bring Spot to a hard stop during termination: {ex}",
+            )
 
         # Block until action sequence is done executing
         while self.processing_action_sequence:
@@ -176,6 +217,8 @@ class SpotExecutor:
     def process_action_sequence(self, sequence, feedback):
         self.processing_action_sequence = True
         self.keep_going = True
+        with self._pause_lock:
+            self.paused = False
 
         try:
             feedback.print("INFO", "Would like to execute: ")
@@ -188,6 +231,15 @@ class SpotExecutor:
             ix = 0
             inner_loop_attempts = 0
             while ix < len(sequence.actions):
+                # Honor pause requests between actions
+                while True:
+                    with self._pause_lock:
+                        is_paused = self.paused
+                    if not is_paused or not self.keep_going:
+                        break
+                    feedback.print("INFO", "Action sequence paused.")
+                    time.sleep(0.1)
+
                 # If the lease manager is actively taking back the lease and getting the
                 # robot to stand back up, we don't want to send it any commands. It will break.
                 if (
@@ -375,5 +427,7 @@ class SpotExecutor:
                 timeout,
                 self.mid_level_planner,
                 feedback=feedback,
+                cancel_cb=lambda: self.keep_going,
+                pause_cb=lambda: self.paused,
             )
         return ret

--- a/spot_tools/src/spot_skills/navigation_utils.py
+++ b/spot_tools/src/spot_skills/navigation_utils.py
@@ -101,6 +101,8 @@ def follow_trajectory_continuous(
     frame_name=VISION_FRAME_NAME,
     stairs=False,
     feedback=None,
+    cancel_cb=None,
+    pause_cb=None,
 ) -> bool:
     """
     Follows a trajectory by commanding the robot to move to each waypoint in the specified frame.
@@ -122,6 +124,31 @@ def follow_trajectory_continuous(
     rate = 10
     # TODO: reactive loop, yeild out the loop to get info
     while 1:
+        # Pause support: stop motion but keep this loop alive so we can resume.
+        if pause_cb is not None and pause_cb():
+            if hasattr(spot, "stand"):
+                try:
+                    spot.stand()
+                except Exception as ex:
+                    feedback.print("WARN", f"Failed to stand Spot while pausing: {ex}")
+            # Stay here until unpaused or cancelled. Track how long we were
+            # paused so it doesn't count against the follow timeout below.
+            pause_start = time.time()
+            while pause_cb() and (cancel_cb is None or cancel_cb()):
+                time.sleep(1 / rate)
+            t0 += time.time() - pause_start
+
+        if cancel_cb is not None and not cancel_cb():
+            # External caller requested cancellation; try to stop motion and exit early.
+            if hasattr(spot, "stand"):
+                try:
+                    spot.stand()
+                except Exception as ex:
+                    feedback.print(
+                        "WARN", f"Failed to stand Spot while cancelling: {ex}"
+                    )
+            return False
+
         curr_time = time.time()
         feedback.print("INFO", f"Timeout progress {curr_time - t0} / {timeout}")
         if curr_time - t0 > timeout:
@@ -201,6 +228,18 @@ def follow_trajectory_continuous(
             return False
 
         navigate_to_absolute_pose(spot, current_waypoint, frame_name, stairs=stairs)
+
+        # Check cancel immediately after sending command so we stop without waiting for sleep
+        if cancel_cb is not None and not cancel_cb():
+            if hasattr(spot, "stand"):
+                try:
+                    spot.stand()
+                except Exception as ex:
+                    feedback.print(
+                        "WARN", f"Failed to stand Spot while cancelling: {ex}"
+                    )
+            return False
+
         time.sleep(1 / rate)
     return True
 

--- a/spot_tools/src/spot_skills/navigation_utils.py
+++ b/spot_tools/src/spot_skills/navigation_utils.py
@@ -21,6 +21,34 @@ MAX_LINEAR_VEL = 0.75
 MAX_ROTATION_VEL = 0.65
 
 
+def command_zero_velocity(spot, feedback=None) -> bool:
+    """Ask Spot to stop moving, via whichever velocity interface it exposes.
+
+    FakeSpot implements set_vel(v_linear, v_angular); the real Spot implements
+    set_twist(vx, vy, v_rot). The two are disjoint, so callers must not probe
+    for just one of them -- doing that silently no-ops on the interface that
+    lacks it, which is how a stop can appear to work in sim and do nothing on
+    hardware.
+
+    Returns True if a zero-velocity command was issued. False means neither
+    interface was available, so the caller cannot assume the robot has been
+    asked to stop and must rely on stand() alone.
+    """
+    if hasattr(spot, "set_vel"):
+        spot.set_vel(np.zeros(3), np.zeros(3))
+        return True
+    if hasattr(spot, "set_twist"):
+        spot.set_twist(0.0, 0.0, 0.0)
+        return True
+    if feedback is not None:
+        feedback.print(
+            "WARNING",
+            "Spot interface exposes neither set_vel nor set_twist; cannot command "
+            "zero velocity, falling back to stand() alone to stop the robot.",
+        )
+    return False
+
+
 def navigate_to_relative_pose(
     spot,
     body_tform_goal: math_helpers.SE2Pose,

--- a/spot_tools/src/spot_skills/navigation_utils.py
+++ b/spot_tools/src/spot_skills/navigation_utils.py
@@ -130,7 +130,9 @@ def follow_trajectory_continuous(
                 try:
                     spot.stand()
                 except Exception as ex:
-                    feedback.print("WARN", f"Failed to stand Spot while pausing: {ex}")
+                    feedback.print(
+                        "WARNING", f"Failed to stand Spot while pausing: {ex}"
+                    )
             # Stay here until unpaused or cancelled. Track how long we were
             # paused so it doesn't count against the follow timeout below.
             pause_start = time.time()
@@ -145,7 +147,7 @@ def follow_trajectory_continuous(
                     spot.stand()
                 except Exception as ex:
                     feedback.print(
-                        "WARN", f"Failed to stand Spot while cancelling: {ex}"
+                        "WARNING", f"Failed to stand Spot while cancelling: {ex}"
                     )
             return False
 
@@ -236,7 +238,7 @@ def follow_trajectory_continuous(
                     spot.stand()
                 except Exception as ex:
                     feedback.print(
-                        "WARN", f"Failed to stand Spot while cancelling: {ex}"
+                        "WARNING", f"Failed to stand Spot while cancelling: {ex}"
                     )
             return False
 

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -2,6 +2,7 @@ import logging
 import os
 import threading
 import time
+import traceback
 
 import numpy as np
 import rclpy
@@ -651,6 +652,23 @@ class SpotExecutorRos(Node):
             self.spot_executor.terminate_sequence(self.feedback_collector)
 
     def process_action_sequence(self, msg):
+        # An exception escaping a subscription callback tears down the rclpy
+        # executor and kills the node. Plan repair means many preemptions in a
+        # row, so one bad plan must degrade rather than end the run.
+        try:
+            self._process_action_sequence(msg)
+        except Exception:
+            self.status_str = "Idle"
+            with self._plan_id_lock:
+                if self._current_plan_id == getattr(msg, "plan_id", None):
+                    self._current_plan_id = None
+            self.get_logger().error(
+                "Failed to handle incoming plan "
+                f"(plan_id={getattr(msg, 'plan_id', '<unknown>')}); node staying up:\n"
+                f"{traceback.format_exc()}"
+            )
+
+    def _process_action_sequence(self, msg):
         # Plan-repair preemption: only accept a new plan when plan_id is different
         with self._plan_id_lock:
             if (
@@ -679,6 +697,13 @@ class SpotExecutorRos(Node):
                 )
 
                 self.get_logger().info("Finished execution action sequence.")
+            except Exception:
+                # Same reasoning as above: report and let the node keep serving
+                # plans instead of leaving a dead executor thread behind.
+                self.get_logger().error(
+                    f"Action sequence (plan_id={msg.plan_id}) aborted:\n"
+                    f"{traceback.format_exc()}"
+                )
             finally:
                 with self._plan_id_lock:
                     if self._current_plan_id == msg.plan_id:

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -28,7 +28,7 @@ from shapely.geometry import Point
 from spot_executor.fake_spot import FakeSpot
 from spot_executor.spot import Spot
 from spot_skills.detection_utils import YOLODetector
-from std_msgs.msg import String
+from std_msgs.msg import Bool, String
 from visualization_msgs.msg import Marker, MarkerArray
 
 from robot_executor_interface.mid_level_planner import (
@@ -386,6 +386,8 @@ class SpotExecutorRos(Node):
         super().__init__("spot_executor_ros")
         self.debug = False
         self.background_thread = None
+        self._current_plan_id = None
+        self._plan_id_lock = threading.Lock()
 
         # Connectivity parameters
         self.declare_parameter("spot_ip", "")
@@ -612,6 +614,16 @@ class SpotExecutorRos(Node):
             timer_period_s, self.hb_callback, callback_group=heartbeat_timer_group
         )
 
+        # External pause/stop control: allow other nodes (e.g. goal_manager) to
+        # pause/resume or hard-stop the current plan.
+        self.pause_sub = self.create_subscription(
+            Bool, "~/pause", self.handle_pause, 10
+        )
+        self.resume_sub = self.create_subscription(
+            Bool, "~/resume", self.handle_resume, 10
+        )
+        self.stop_sub = self.create_subscription(Bool, "~/stop", self.handle_stop, 10)
+
     def hb_callback(self):
         msg = NodeInfoMsg()
         msg.nickname = "spot_executor"
@@ -620,20 +632,58 @@ class SpotExecutorRos(Node):
         msg.notes = self.status_str
         self.heartbeat_pub.publish(msg)
 
-    def process_action_sequence(self, msg):
-        def process_sequence():
-            self.status_str = "Processing action sequence"
-            self.get_logger().info("Starting action sequence")
-            sequence = from_msg(msg)
+    def handle_pause(self, msg: Bool):
+        if msg.data:
+            self.get_logger().info("Received external pause request.")
+            self.spot_executor.set_paused(True, self.feedback_collector)
 
-            self.spot_executor.process_action_sequence(
-                sequence, self.feedback_collector
-            )
-            self.get_logger().info("Finished execution action sequence.")
-            self.status_str = "Idle"
+    def handle_resume(self, msg: Bool):
+        if msg.data:
+            self.get_logger().info("Received external resume request.")
+            self.spot_executor.set_paused(False, self.feedback_collector)
 
+    def handle_stop(self, msg: Bool):
+        # Best-effort hard stop of the current action sequence, if any.
         if self.background_thread is not None and self.background_thread.is_alive():
+            self.get_logger().info(
+                "Received external stop request; terminating current plan."
+            )
             self.spot_executor.terminate_sequence(self.feedback_collector)
+
+    def process_action_sequence(self, msg):
+        # Plan-repair preemption: only accept a new plan when plan_id is different
+        with self._plan_id_lock:
+            if (
+                self._current_plan_id is not None
+                and msg.plan_id == self._current_plan_id
+            ):
+                self.get_logger().info(
+                    f"Ignoring duplicate plan (plan_id={msg.plan_id}), already executing"
+                )
+                return
+            if self.background_thread is not None and self.background_thread.is_alive():
+                self.get_logger().info(
+                    f"Preempting current plan (plan_id={self._current_plan_id}) with new plan (plan_id={msg.plan_id})"
+                )
+                self.spot_executor.terminate_sequence(self.feedback_collector)
+            self._current_plan_id = msg.plan_id
+
+        def process_sequence():
+            try:
+                self.status_str = "Processing action sequence"
+                self.get_logger().info("Starting action sequence")
+                sequence = from_msg(msg)
+
+                self.spot_executor.process_action_sequence(
+                    sequence, self.feedback_collector
+                )
+
+                self.get_logger().info("Finished execution action sequence.")
+            finally:
+                with self._plan_id_lock:
+                    if self._current_plan_id == msg.plan_id:
+                        self._current_plan_id = None
+                self.status_str = "Idle"
 
         self.feedback_collector.break_out_of_waiting_loop = False
         self.feedback_collector.plan_valid = True

--- a/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
+++ b/spot_tools_ros/src/spot_tools_ros/spot_executor_ros.py
@@ -234,18 +234,24 @@ class RosFeedbackCollector:
         pass
 
     def print(self, level, string):
+        # rclpy keys its logging context on CallerId -- (function, file, line) --
+        # and refuses to log a second severity from a call site it has already
+        # seen. Binding log_fn and calling it from one shared line made every
+        # level share a call site, so the first WARNING after an INFO raised
+        # "Logger severity cannot be changed between calls." Each severity needs
+        # its own line.
+        message = str(string)
         match level:
             case "DEBUG":
-                log_fn = self.logger.debug
+                self.logger.debug(message)
             case "INFO":
-                log_fn = self.logger.info
+                self.logger.info(message)
             case "WARNING":
-                log_fn = self.logger.warning
+                self.logger.warning(message)
             case "ERROR":
-                log_fn = self.logger.error
+                self.logger.error(message)
             case _:
                 raise ValueError(f"Invalid log level {level}")
-        log_fn(str(string))
 
         # TODO(multy): quick logic to log everything we print in the executor
         if self.log_to_file_level != "":


### PR DESCRIPTION
Plan-repair (in `awesome_dcist_t4`/`omniplanner`) needs to pause Spot mid-execution to check whether a new goal is already covered, and hard-preempt the current plan when a replan happens. The executor previously had no way to interrupt a running action sequence -- this adds pause/resume/stop and plan-preemption support end to end, in both sim and real Spot.

## Changes

**`spot_executor.py`**
Adds `set_paused()` and a per-action pause loop, plus a real hard stop (`set_vel(0,0)` + `stand()`) inside `terminate_sequence()`. Without this, "terminating" a sequence only stopped new actions from starting -- the robot could keep moving. Now pause/stop actually halts the robot and holds it standing in place.

**`navigation_utils.py`**
Adds `cancel_cb`/`pause_cb` params to `follow_trajectory_continuous`, checked inside its control loop. A single `follow` action can be a long multi-waypoint trajectory, so without checking these callbacks *inside* the loop, pause/stop only took effect between actions -- a long trajectory would run to completion regardless. Also lowers `MAX_LINEAR_VEL`/`MAX_ROTATION_VEL` (0.75/0.65 -> 0.25/0.25) for demo. It is not mandatory to make changes.

**`fake_spot.py`**
Changes sim motion from an instant teleport to 10 Hz interpolated steno "mid-motion" moment to actually preempt, so pause/cancel behavior was untestable in sim. This makes preemption visibly work the same way in fake-Spot as on real Spot.

**`spot_executor_ros.py`**
Adds `~/pause`, `~/resume`, `~/stop` topics so external nodes ( `goal_executor` , and tracks `_current_plan_id` so a new `ActionSequenceMsg` with a different plan ID hard-preempts the currently running one instead of being ignored or racing against it.